### PR TITLE
import window controls in dark version

### DIFF
--- a/gtk-3.0/gtk-dark.css
+++ b/gtk-3.0/gtk-dark.css
@@ -221,3 +221,4 @@
 @import url("gnome-applications.css");
 @import url("granite-widgets.css");
 @import url("gnome-applications-dark-overrides.css");
+@import url("window-control.css");


### PR DESCRIPTION
Forgot to do that. Apps in dark version (such as Terminal) was without any window buttons.
