### PR TITLE
Fixed buttons in unfocused dark windows

### DIFF
--- a/gtk-3.0/css/dark/window-control.css
+++ b/gtk-3.0/css/dark/window-control.css
@@ -1,14 +1,16 @@
-.titlebar .left .titlebutton:nth-child(2):backdrop {
-	background-image: url('window-controls/unfocused_dark.svg');
-	-gtk-image-effect: dim;
-}
-
-.titlebar .left .titlebutton:first-child:backdrop {
-	background-image: url('window-controls/unfocused_dark.svg');
-	-gtk-image-effect: dim;
-}
-
+.titlebar .left .titlebutton:nth-child(2):backdrop,
+.titlebar .left .titlebutton:first-child:backdrop,
 .titlebar .left .titlebutton:nth-child(3):backdrop {
-	background-image: url('window-controls/unfocused_dark.svg');
+	background-image: url('../window-controls/unfocused_dark.svg');
+	-gtk-image-effect: dim;
+}
+
+.titlebar .left .titlebutton:nth-child(2):backdrop:hover,
+.titlebar .left .titlebutton:first-child:backdrop:hover,
+.titlebar .left .titlebutton:nth-child(3):backdrop:hover,
+.titlebar .left .titlebutton:nth-child(2):backdrop:active,
+.titlebar .left .titlebutton:first-child:backdrop:active,
+.titlebar .left .titlebutton:nth-child(3):backdrop:active {
+	background-image: url('../window-controls/titlebar_button.svg');
 	-gtk-image-effect: dim;
 }

--- a/gtk-3.0/css/window-control.css
+++ b/gtk-3.0/css/window-control.css
@@ -45,7 +45,7 @@
 	background-image: url('window-controls/min_prelight.svg');
 }
 
-.titlebar .left .titlebutton:nth-child(2):active{
+.titlebar .left .titlebutton:nth-child(2):active {
 	background-image: url('window-controls/min_pressed.svg');
 }
 
@@ -59,7 +59,7 @@
 	-gtk-image-effect: dim;
 }
 
-.titlebar .left .titlebutton:first-child:hover{
+.titlebar .left .titlebutton:first-child:hover {
 	background-image: url('window-controls/close_prelight.svg');
 }
 


### PR DESCRIPTION
Experemental: use titlebar_button.svg for hovered/active window buttons in unfocused black windows
