### PR TITLE
Fix a minor problem with the copy-paste script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ If you find a bug or want an improvement in any way, simply raise an issue and w
 # [Installation](https://github.com/eOS-themes/Xenite/wiki/Installation)
 To install Xenite, simply run the following command:
 ```shell
-sudo sh -c "curl https://raw.githubusercontent.com/eOS-themes/Xenite/master/setup/install.sh | bash"
+sudo sh -c "$(curl -sL https://raw.githubusercontent.com/eOS-themes/Xenite/master/setup/install.sh)"
 ```
 If error similar to the following:-
 ```shell


### PR DESCRIPTION
This style works better and doesnt show the error, at least for me. [ohmyzsh](http://ohmyz.sh) uses a line similar to this to setup their script
